### PR TITLE
Revert audio targets to debian

### DIFF
--- a/ros-audio_capture/install.yaml
+++ b/ros-audio_capture/install.yaml
@@ -1,5 +1,4 @@
 - type: ros
   source:
-    type: git
-    url: https://github.com/tue-robotics/audio_common.git
-    sub-dir: audio_capture
+    type: system
+    name: audio-capture

--- a/ros-audio_common_msgs/install.yaml
+++ b/ros-audio_common_msgs/install.yaml
@@ -1,5 +1,4 @@
 - type: ros
   source:
-    type: git
-    url: https://github.com/tue-robotics/audio_common.git
-    sub-dir: audio_common_msgs
+    type: system
+    name: audio-common-msgs


### PR DESCRIPTION
Because https://github.com/tue-robotics/audio_common.git is matching upstream. So this repo can be deleted.