### PR TITLE
shellcheck -x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,5 @@ addons:
     packages:
       - yamllint
 script:
-  - bash -c 'shopt -s globstar; shellcheck **/*.bash **/*.sh **/setup'
+  - bash -c 'shopt -s globstar; shellcheck -x **/*.bash **/*.sh **/setup'
   - bash -c 'find ./ -iname '*.yaml' -or -iname '*.yml' | xargs yamllint'


### PR DESCRIPTION
Use shellcheck -x to allow following of sourced files. (SC1091)

SC1091 is disabled in 3 targets as they source `/etc/lsb-release`. This is a system file. So it shouldn't be checked.