### PR TITLE
Change ROS package git to system install

### DIFF
--- a/ros-kdl/install.yaml
+++ b/ros-kdl/install.yaml
@@ -1,4 +1,0 @@
-- type: ros
-  source:
-    type: system
-    name: kdl

--- a/ros-kdl_parser/install.yaml
+++ b/ros-kdl_parser/install.yaml
@@ -1,6 +1,4 @@
 - type: ros
   source:
-    type: git
-    url: https://github.com/ros/kdl_parser.git
-    version: kinetic-devel
-    sub-dir: kdl_parser
+    type: system
+    name: kdl-parser

--- a/ros-orocos_kdl/install.yaml
+++ b/ros-orocos_kdl/install.yaml
@@ -1,5 +1,4 @@
 - type: ros
   source:
-    type: git
-    url: https://github.com/orocos/orocos_kinematics_dynamics.git
-    sub-dir: orocos_kdl
+    type: system
+    name: orocos-kdl

--- a/ros-python_orocos_kdl/install.yaml
+++ b/ros-python_orocos_kdl/install.yaml
@@ -1,7 +1,4 @@
 - type: ros
   source:
-    type: git
-    url: https://github.com/orocos/orocos_kinematics_dynamics.git
-    sub-dir: python_orocos_kdl
-    # temp for getting everyone back to master instead of specific commit Matthijs 01-04-2018
-    version: master
+    type: system
+    name: python-orocos-kdl


### PR DESCRIPTION
A system package exists for all the changed packages.

Two questions here though,
1. Apart from Orocos-KDL, are we using `python-sip` anywhere else? If not then we can change it to system package too.
2. Where are we using `orocos-toolchain`? If we are not using it anywhere then it needs to be removed.