### PR TITLE
possible fix for hero start/reboot

### DIFF
--- a/hero1/setup
+++ b/hero1/setup
@@ -8,3 +8,44 @@ done < /etc/opt/tmc/robot/version
 
 alias hero-sync-ubuntu-ntp="sudo ntpdate ntp.ubuntu.com"
 alias hero-restart="sudo systemctl restart hero-start.service"
+
+function _vbox_sleep
+{
+    sleep 1;
+    local i
+    i=0
+    while [[ $i -lt 30 ]]
+    do
+        if [[ -z $(lsmod | grep vbox) ]]
+        then
+            echo "All vbox modules stopped"
+            return 0
+        fi
+        sleep 0.5
+        i=$((i+1))
+    done
+    echo "Not all vbox modules stopped"
+}
+
+function _stop_vbox_services
+{
+    sudo systemctl stop hero1-windows-speech.service
+    sudo systemctl stop hero1-vboxautostart-service.service
+    sudo systemctl stop hero1-vboxweb-service.service
+    sudo systemctl stop hero1-vboxballoonctrl-service.service
+    sudo systemctl stop hero1-vboxdrv.service
+}
+
+function hero-reboot
+{
+    _stop_vbox_services
+    _vbox_sleep
+    sudo reboot
+}
+
+function hero-shutdown
+{
+    _stop_vbox_services
+    _vbox_sleep
+    sudo shutdown -h -t 0
+}

--- a/hero1/setup
+++ b/hero1/setup
@@ -16,7 +16,7 @@ function _vbox_sleep
     i=0
     while [[ $i -lt 30 ]]
     do
-        if [[ -z $(lsmod | grep vbox) ]]
+        if ! lsmod | grep -q vbox
         then
             echo "All vbox modules stopped"
             return 0


### PR DESCRIPTION
only use `hero-reboot` or `hero-shutdown`

No guarantees, Still gets into corrupted boot. But way less times.

Reboot is way more robust than shutdown.