### PR TITLE
Refactor hsr-setup

### DIFF
--- a/gazebo/install.bash
+++ b/gazebo/install.bash
@@ -1,15 +1,14 @@
 #! /usr/bin/env bash
 
-if [ ! -f /etc/apt/sources.list.d/gazebo-latest.list ]
+if [ ! -f /etc/apt/sources.list.d/gazebo-stable.list ]
 then
-    # Setup your computer to accept software from packages.osrfoundation.org.
-    sudo sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu precise main" > /etc/apt/sources.list.d/gazebo-latest.list'
+    tue-install-debug "Adding Gazebo sources to apt-get"
+    sudo sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list'
 
-    # Retrieve and install the keys for the Gazebo repositories.
     wget http://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add -
 
-    sudo apt-get update
+    sudo apt-get update -qq
+    tue-install-debug "Added Gazebo sources to apt-get successfully"
+else
+    tue-install-debug "Gazebo sources already added to apt-get"
 fi
-
-# install Gazebo
-tue-install-system gazebo

--- a/gazebo/install.yaml
+++ b/gazebo/install.yaml
@@ -1,0 +1,2 @@
+- type: system
+  name: gazebo

--- a/hero1/install.yaml
+++ b/hero1/install.yaml
@@ -15,6 +15,9 @@
 - type: target
   name: ros-test_tools
 
+- type: target
+  name: hsr-setup
+
 - type: ros
   source:
     type: system

--- a/hsr-setup/install.bash
+++ b/hsr-setup/install.bash
@@ -12,12 +12,10 @@ then
     fi
 
     tue-install-debug "Adding HSR sources to apt-get"
-    sudo sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list'
     sudo sh -c 'echo "deb https://packages.hsr.io/ros/ubuntu `lsb_release -cs` main" > /etc/apt/sources.list.d/tmc.list'
     sudo sh -c 'echo "deb https://packages.hsr.io/tmc/ubuntu `lsb_release -cs` multiverse main" >> /etc/apt/sources.list.d/tmc.list'
 
     wget https://hsr-user:jD3k4G2e@packages.hsr.io/tmc.key -O - | sudo apt-key add -
-    wget http://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add -
 
     sudo apt-get update -qq
     tue-install-debug "Added HSR sources to apt-get succesfully"

--- a/hsr-setup/install.bash
+++ b/hsr-setup/install.bash
@@ -2,12 +2,23 @@
 
 if [ ! -f "/etc/apt/sources.list.d/tmc.list" ]
 then
+    if [ ! -f "/etc/apt/auth.conf.d/tmc.conf" ]
+    then
+        tue-install-debug "Adding HSR repository login credentials to apt-get"
+        sudo sh -c 'echo "machine packages.hsr.io login hsr-user password jD3k4G2e" > /etc/apt/auth.conf.d/tmc.conf'
+        tue-install-debug "Added HSR repository login credentials to apt-get succesfully"
+    else
+        tue-install-debug "HSR repository login credentials already added to apt-get"
+    fi
+
     tue-install-debug "Adding HSR sources to apt-get"
-    sudo sh -c 'echo "deb https://hsr-user:jD3k4G2e@packages.hsr.io/ros/ubuntu `lsb_release -cs` main" > /etc/apt/sources.list.d/tmc.list'
-    sudo sh -c 'echo "deb https://hsr-user:jD3k4G2e@packages.hsr.io/tmc/ubuntu `lsb_release -cs` multiverse main" >> /etc/apt/sources.list.d/tmc.list'
     sudo sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list'
+    sudo sh -c 'echo "deb https://packages.hsr.io/ros/ubuntu `lsb_release -cs` main" > /etc/apt/sources.list.d/tmc.list'
+    sudo sh -c 'echo "deb https://packages.hsr.io/tmc/ubuntu `lsb_release -cs` multiverse main" >> /etc/apt/sources.list.d/tmc.list'
+
     wget https://hsr-user:jD3k4G2e@packages.hsr.io/tmc.key -O - | sudo apt-key add -
     wget http://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add -
+
     sudo apt-get update -qq
     tue-install-debug "Added HSR sources to apt-get succesfully"
 else

--- a/hsr-setup/install.yaml
+++ b/hsr-setup/install.yaml
@@ -1,0 +1,2 @@
+- type: target
+  name: gazebo

--- a/ros-hsrb_description/install.yaml
+++ b/ros-hsrb_description/install.yaml
@@ -1,3 +1,6 @@
+- type: target
+  name: hsr-setup
+
 - type: ros
   source:
     type: system

--- a/ros-tmc-desktop-full/install.yaml
+++ b/ros-tmc-desktop-full/install.yaml
@@ -1,3 +1,6 @@
+- type: target
+  name: hsr-setup
+
 - type: ros
   source:
     type: system

--- a/ros-tmc_msgs/install.yaml
+++ b/ros-tmc_msgs/install.yaml
@@ -1,3 +1,6 @@
+- type: target
+  name: hsr-setup
+
 - type: ros
   source:
     type: system

--- a/ros-tue_hsr/install.yaml
+++ b/ros-tue_hsr/install.yaml
@@ -1,4 +1,0 @@
-- type: ros
-  source:
-    type: git
-    url: https://github.com/tue-robotics/tue_hsr.git

--- a/ros/install.bash
+++ b/ros/install.bash
@@ -25,7 +25,7 @@ then
 fi
 
 # TEMP fix for to only update the key
-if ! apt-key list | grep -q 4096R/AB17C654
+if ! apt-key adv --list-public-keys | grep -q AB17C654
 then
     sudo apt-key del 421C365BD9FF1F717815A3895523BAEEB01FA116
     sudo apt-key adv --keyserver 'hkp://keyserver.ubuntu.com:80' --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654


### PR DESCRIPTION
- [x] Fix authentication of tmc repository (fixes apt-get update warning)
- [x] Fix gazebo sources (broken source link)
- [x] Make gazebo a dependency of hsr-setup
- [x] Make hsr-setup a explicit dependency of hsr, tmc and hero targets
- [x] Fix ROS gpg key check (broken in Bionic as it was not robust)