### PR TITLE
[python-catkin-tools-document] back to pip release

### DIFF
--- a/python-catkin-tools-document-pip/install.yaml
+++ b/python-catkin-tools-document-pip/install.yaml
@@ -1,2 +1,2 @@
 - type: pip
-  name: git+https://github.com/tue-robotics/catkin_tools_document.git
+  name: catkin-tools-document>=0.2.0


### PR DESCRIPTION
New release as mentioned in https://github.com/mikepurvis/catkin_tools_document/issues/12