### PR TITLE
Refactor export of variables

### DIFF
--- a/ccache/setup
+++ b/ccache/setup
@@ -1,3 +1,6 @@
 #! /usr/bin/env bash
 
-export PATH=/usr/lib/ccache:$PATH
+if [[ :$PATH: != *:/usr/lib/ccache:* ]]
+then
+    export PATH=/usr/lib/ccache:${PATH:+:${PATH}}
+fi

--- a/cuda/setup
+++ b/cuda/setup
@@ -1,5 +1,11 @@
 #! /usr/bin/env bash
 
-export PATH=/usr/local/cuda/bin${PATH:+:${PATH}}
+if [[ :$PATH: != *:/usr/local/cuda/bin:* ]]
+then
+    export PATH=/usr/local/cuda/bin${PATH:+:${PATH}}
+fi
 
-export LD_LIBRARY_PATH=/usr/local/cuda/lib64${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+if [[ :$LD_LIBRARY_PATH: != *:/usr/local/cuda/lib64:* ]]
+then
+    export LD_LIBRARY_PATH=/usr/local/cuda/lib64${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+fi


### PR DESCRIPTION
Direct exporting leads to pollution of the path variable when a terminal is resourced. This PR cleans up bash variables.