### PR TITLE
[tue-middleware] remove dep on tue_manipulation

### DIFF
--- a/tue-middleware/install.yaml
+++ b/tue-middleware/install.yaml
@@ -15,10 +15,6 @@
 - type: target
   name: ros-dwa_local_planner
 
-# Manipulation
-- type: target
-  name: ros-tue_manipulation
-
 # SLAM
 - type: target
   name: ros-gmapping


### PR DESCRIPTION
Not needed on HERO, used on AMIGO/SERGIO. but already included in amigo/sergio-start, so no need to be here too