### PR TITLE
Leg tracker targets

### DIFF
--- a/libfftw3/install.yaml
+++ b/libfftw3/install.yaml
@@ -1,0 +1,5 @@
+- type: system
+  name: libfftw3-3
+
+- type: system
+  name: libfftw3-dev

--- a/ros-leg_tracker/install.yaml
+++ b/ros-leg_tracker/install.yaml
@@ -1,0 +1,4 @@
+- type: ros
+  source:
+    type: git
+    url: https://github.com/tue-robotics/leg_tracker.git


### PR DESCRIPTION
libfftw3 matches rosdistro, https://github.com/ros/rosdistro/blob/9eb14c896d4b37e6467f39efbc00889b983c6b75/rosdep/base.yaml#L2025.

@TPCWester After this PR is merged, you can install the `leg_tracker` via tue-get, `tue-get install ros-leg_tracker`. This will override the symbolic link in the workspace. So the old cloned repo will not be used anymore in that case.