### PR TITLE
Move hsr-setup to private github repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "hsr-setup"]
-	path = hsr-setup
-	url = git@gitlab.com:tue-robotics/hsr-setup.git
+    path = hsr-setup
+    url = git@github.com:tue-robotics/hsr-setup.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ os: linux
 dist: bionic
 language: shell
 addons:
-  ssh_known_hosts: gitlab.com
   apt:
     packages:
       - python3-pip


### PR DESCRIPTION
`tue-get` doesn't change the remote of the submodule.

Should only be merged if CI of https://github.com/tue-robotics/hero_bringup/pull/53 and https://github.com/tue-robotics/hero_bridge/pull/15 succeeds