### PR TITLE
[python-telegram-bot] limit version because of python2 compatibility

### DIFF
--- a/python-telegram-bot/install.yaml
+++ b/python-telegram-bot/install.yaml
@@ -1,5 +1,5 @@
 - type: pip
-  name: python-telegram-bot
+  name: python-telegram-bot<12.7
 
 # Fix pip ffi.h header missing error
 - type: system


### PR DESCRIPTION
Fixes datetime no arribute timezone

Needed because https://github.com/python-telegram-bot/python-telegram-bot/pull/1621 is not compatible with python2, which is added in 12.7.