### PR TITLE
[ros-cb_base_navigation_msgs] rename repo

### DIFF
--- a/ros-cb_base_navigation_msgs/install.yaml
+++ b/ros-cb_base_navigation_msgs/install.yaml
@@ -1,4 +1,4 @@
 - type: ros
   source:
     type: git
-    url: https://github.com/tue-robotics/cb_planner_msgs_srvs.git
+    url: https://github.com/tue-robotics/cb_base_navigation_msgs.git


### PR DESCRIPTION
In the meantime, github will redirect the old url to the new one