### PR TITLE
[networking] install net-tools for ifconfig

### DIFF
--- a/networking/install.yaml
+++ b/networking/install.yaml
@@ -8,3 +8,5 @@
   name: nmap # General debugging utility typically not easy to install during network troubles
 - type: system
   name: ssh # Used for logging into this computer
+- type: system
+  name: net-tools # Provides ifconfig


### PR DESCRIPTION
Not installed by default on Ubuntu 18.04