### PR TITLE
[ros-setup] Fix expired ROS GPG key

### DIFF
--- a/ros-setup/install.bash
+++ b/ros-setup/install.bash
@@ -5,10 +5,17 @@ then
     tue-install-echo "Adding ROS sources to apt-get"
     sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list'
 
-    sudo apt-key adv --keyserver 'hkp://keyserver.ubuntu.com:80' --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
+    tue-install-pipe sudo apt-key adv --keyserver 'hkp://keyserver.ubuntu.com:80' --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
 
     tue-install-apt-get-update
     tue-install-debug "Added ROS sources to apt-get successfully"
 else
     tue-install-debug "ROS sources already added to apt-get"
+fi
+
+# Check for expired key and update
+if sudo apt-key adv --list-keys C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654 2>/dev/null | grep -q expired
+then
+    tue-install-echo "Updating expired GPG key"
+    tue-install-pipe sudo apt-key adv --keyserver 'hkp://keyserver.ubuntu.com:80' --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
 fi

--- a/ros-setup/install.bash
+++ b/ros-setup/install.bash
@@ -12,10 +12,3 @@ then
 else
     tue-install-debug "ROS sources already added to apt-get"
 fi
-
-# TEMP fix for to only update the key
-if ! apt-key adv --list-public-keys 2>/dev/null | grep -q AB17C654
-then
-    sudo apt-key del 421C365BD9FF1F717815A3895523BAEEB01FA116
-    sudo apt-key adv --keyserver 'hkp://keyserver.ubuntu.com:80' --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
-fi


### PR DESCRIPTION
ROS forgot to update the expiration date of their GPG key: https://discourse.ros.org/t/ros-gpg-key-expiration-incident/20669

Generating a new docker image would fix CI, but not the local machines

Old image without check&update: https://github.com/tue-robotics/code_profiler/runs/2703509679?check_suite_focus=true
Old image with check&update: https://github.com/tue-robotics/code_profiler/runs/2703666019?check_suite_focus=true
