### PR TITLE
[ros] only run rosdep update on installed distro

### DIFF
--- a/ros/install.bash
+++ b/ros/install.bash
@@ -19,7 +19,7 @@ rosdep_update_file="/tmp/tue_rosdep_update_${USER}"
 if [ ! -f "$rosdep_update_file" ]
 then
     tue-install-debug "Updating rosdep"
-    tue-install-pipe rosdep update
+    tue-install-pipe rosdep update --rosdistro "$TUE_ROS_DISTRO"
     touch "$rosdep_update_file"
 fi
 


### PR DESCRIPTION
This reduces the update time a little bit. Plus no need to pull the other distros.