### PR TITLE
[tue-documentation-github] remove ros-virtual_cam

### DIFF
--- a/tue-documentation-github/install.yaml
+++ b/tue-documentation-github/install.yaml
@@ -233,8 +233,6 @@
 - type: target
   name: ros-upower_ros
 - type: target
-  name: ros-virtual_cam
-- type: target
   name: ros-wire
 - type: target
   name: ros-wire_core


### PR DESCRIPTION
Only used in fast_simulator, which is also closed to being deprecated. So no need for documentation generation. Also because there are no docstrings