### PR TITLE
moveit2

### DIFF
--- a/ros-hsrb_moveit_config/install.yaml
+++ b/ros-hsrb_moveit_config/install.yaml
@@ -1,4 +1,5 @@
 - type: ros
   source:
     type: git
-    url: https://github.com/tue-robotics/hsrb_moveit_config.git
+    url: git@github.com:tue-robotics/hsrb_moveit.git
+    sub-dir: hsrb_moveit_config


### PR DESCRIPTION
This reverts commit b1d8ae6afbba9d6ee968d21eb72dc7fafbb07109.

It is clear that this will be the repo that will be used. So no need for the master to point to the repo that isn't going to be used at all.