### PR TITLE
[python3-catkin-tools] remove pip installed version

### DIFF
--- a/python3-catkin-tools/check_installed_version.py
+++ b/python3-catkin-tools/check_installed_version.py
@@ -1,0 +1,26 @@
+#! /usr/bin/env python3
+
+import site
+import sys
+
+pip_user_site = site.getusersitepackages()
+pip_system_site = site.getsitepackages()[0]
+
+
+def catkin_tools_pip_installed():
+    try:
+        import catkin_tools
+    except ImportError:
+        return False
+
+    if pip_user_site in catkin_tools.__file__:
+        print("user")
+        return True
+    elif pip_system_site in catkin_tools.__file__:
+        print("system")
+        return True
+
+    return False
+
+if __name__ == "__main__":
+    sys.exit(catkin_tools_pip_installed())

--- a/python3-catkin-tools/install.bash
+++ b/python3-catkin-tools/install.bash
@@ -1,11 +1,28 @@
 # TEMP: should be remove not later then 2022-06-24
+# Also delete check_installed_version.py
 
-catkin_version=$(catkin --version | awk 'NR==1{print $2}')
+catkin_version=$(catkin --version 2>/dev/null | awk 'NR==1{print $2}')
 
 if dpkg --compare-versions "${catkin_version}" lt 0.8.5
 then
     tue-install-info "Upgrading catkin-tools to >= 0.8.5, as 0.8.3 and 0.8.4 are broken"
-    tue-install-pipe sudo apt-get install --assume-yes python3-catkin-tools
+    DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+    while ! install_location=$("$DIR"/check_installed_version.py)
+    do
+        if [ "$install_location" == "user" ]
+        then
+            tue-install-info "Removing pip user installed version of catkin-tools"
+            tue-install-pipe pip uninstall catkin-tools -y
+        elif [ "$install_location" == "system" ]
+        then
+            tue-install-info "Removing pip system installed version of catkin-tools"
+            tue-install-pipe sudo -H pip uninstall catkin-tools -y
+        else
+            tue-install-error "pip install location can only by user or system"
+        fi
+    done
+    # --reinstall is needed as a system installed pip version will replace /usr/bin/catkin, which gets deleted
+    tue-install-pipe sudo apt-get install --assume-yes python3-catkin-tools --reinstall
 else
     tue-install-debug "Not updating catkin-tools. Installed version: ${catkin_version}"
 fi


### PR DESCRIPTION
Only when not meeting the minimal version, which would result in installing the system version on each run.

Fixes https://github.com/tue-robotics/tue-env-targets/issues/290