### PR TITLE
fix: tue-robocup-at-home has been replaced by ros-tue_robocup

### DIFF
--- a/amigo2/install.yaml
+++ b/amigo2/install.yaml
@@ -13,6 +13,6 @@
 
 # RoboCup
 - type: target
-  name: tue-robocup-at-home
+  name: ros-tue_robocup
 - type: target
   name: ros-amigo_skills

--- a/hero-dev/install.yaml
+++ b/hero-dev/install.yaml
@@ -23,7 +23,7 @@
 # -------------------- ROBOCUP --------------------
 
 - type: target
-  name: tue-robocup-at-home
+  name: ros-tue_robocup
 - type: target
   name: ros-hero_skills
 

--- a/sergio2/install.yaml
+++ b/sergio2/install.yaml
@@ -28,6 +28,6 @@
 
 # RoboCup
 - type: target
-  name: tue-robocup-at-home
+  name: ros-tue_robocup
 - type: target
   name: ros-sergio_skills

--- a/tue-dev/install.yaml
+++ b/tue-dev/install.yaml
@@ -25,7 +25,7 @@
 # -------------------- ROBOCUP --------------------
 
 - type: target
-  name: tue-robocup-at-home
+  name: ros-tue_robocup
 - type: target
   name: ros-amigo_skills
 - type: target


### PR DESCRIPTION
Missed files from https://github.com/tue-robotics/tue-env-targets/pull/338