### PR TITLE
[ros] use `--no-status`  for tue-make in CI

### DIFF
--- a/ros/install.bash
+++ b/ros/install.bash
@@ -28,5 +28,7 @@ mkdir -p "$TUE_SYSTEM_DIR"
 if [ ! -f "$TUE_SYSTEM_DIR"/devel/setup.bash ]
 then
     [[ -z "${TUE_ROS_VERSION}" ]] && { tue-install-warning "tue-env variable TUE_ROS_VERSION is not set. This will not be allowed in the future.\nSetting TUE_ROS_VERSION=1 temporarily."; }
-    TUE_ROS_VERSION=1 tue-make || tue-install-error "Error in building the system workspace"
+    [[ "$CI" == "true" ]] && status_args=" --no-status"
+    # shellcheck disable=SC2086
+    TUE_ROS_VERSION=1 tue-make${status_args} || tue-install-error "Error in building the system workspace"
 fi


### PR DESCRIPTION
Old: https://github.com/tue-robotics/tue-env/actions/runs/4167154119/jobs/7212387099#step:4:1562
New: https://github.com/tue-robotics/tue-env/actions/runs/4167154119/jobs/7212658972#step:4:1579

Old:
```
#19 60.85 Starting >>> catkin_tools_prebuild                                             
#19 60.85 [build 0.1 s] [0/1 complete] [1/2 jobs] [0 queued] [catkin_tools_prebuild:c... 
[build 0.2 s] [0/1 complete] [1/2 jobs] [0 queued] [catkin_tools_prebuild:c... 
[build 0.3 s] [0/1 complete] [1/2 jobs] [0 queued] [catkin_tools_prebuild:c... 
[build 0.4 s] [0/1 complete] [1/2 jobs] [0 queued] [catkin_tools_prebuild:c... 
[build 0.5 s] [0/1 complete] [1/2 jobs] [0 queued] [catkin_tools_prebuild:c... 
[build 0.6 s] [0/1 complete] [1/2 jobs] [0 queued] [catkin_tools_prebuild:c... 
[build 0.7 s] [0/1 complete] [1/2 jobs] [0 queued] [catkin_tools_prebuild:c... 
[build 0.8 s] [0/1 complete] [1/2 jobs] [0 queued] [catkin_tools_prebuild:c... 
[build 0.9 s] [0/1 complete] [1/2 jobs] [0 queued] [catkin_tools_prebuild:c... 
[build 1.0 s] [0/1 complete] [1/2 jobs] [0 queued] [catkin_tools_prebuild:c... 
[build 1.1 s] [0/1 complete] [1/2 jobs] [0 queued] [catkin_tools_prebuild:c... 
Finished <<< catkin_tools_prebuild                [ 1.2 seconds ] 
```
New:
```
#19 66.58 Starting >>> catkin_tools_prebuild               
#19 66.58 Finished <<< catkin_tools_prebuild                [ 1.2 seconds ]
```