### PR TITLE
[python-tensorflow-pip] set min version of tensorflow

### DIFF
--- a/python-tensorflow-pip/install.yaml
+++ b/python-tensorflow-pip/install.yaml
@@ -1,2 +1,2 @@
 - type: pip
-  name: tensorflow
+  name: tensorflow>=2.13


### PR DESCRIPTION
Only merge this when change of https://github.com/tue-robotics/image_recognition/pull/196 are not backwards compatible.