### PR TITLE
Updated TUE variable names

### DIFF
--- a/amigo-user/setup
+++ b/amigo-user/setup
@@ -1,6 +1,9 @@
 #! /usr/bin/env bash
 
-export ROBOT_BRINGUP_PATH=$TUE_SYSTEM_DIR/src/amigo_bringup
+# TODO(anyone): remove when tue-env is updated to new variable names
+[[ -v TUE_ENV_WS_DIR || ! -v TUE_WS_DIR ]] || TUE_ENV_WS_DIR=${TUE_WS_DIR}
+
+export ROBOT_BRINGUP_PATH=${TUE_ENV_WS_DIR}/src/amigo_bringup
 
 alias amigo-get-and-view-pdf-from-amigo1.local-home='mkdir -p ~/amigo1pdf && cd ~/amigo1pdf && scp amigo1.local:~/*.pdf . && evince *.pdf'
 alias amigo-core='_robot-core amigo1'
@@ -78,7 +81,7 @@ alias amigo-show-ed-kinect='rosrun rgbd multitool --rgbd /amigo/ed/kinect/viz/up
 #
 ####################
 
-alias amigo='export ROBOT_BRINGUP_PATH=$TUE_SYSTEM_DIR/src/amigo_bringup'
+alias amigo='[[ -v TUE_ENV_WS_DIR || ! -v TUE_WS_DIR ]] || TUE_ENV_WS_DIR=${TUE_WS_DIR}; export ROBOT_BRINGUP_PATH=${TUE_ENV_WS_DIR}/src/amigo_bringup'
 
 alias amigo-continui='rosrun hmi_server continue_gui.py __ns:=amigo/hmi'
 alias amigo-continui-gpsr='rosrun hmi_server continue_gui.py $TUE_SYSTEM_DIR/src/challenge_gpsr/src/grammar_gui.fcfg __ns:=amigo/hmi'

--- a/hero-demo-laptop/shortcuts/hero-rviz.desktop
+++ b/hero-demo-laptop/shortcuts/hero-rviz.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Type=Application
-Exec=bash -c "shopt -s expand_aliases && source ~/.tue/setup.bash; cp -f $TUE_SYSTEM_DIR/src/hero_bringup/parameters/tools/rviz_config.rviz /tmp/rviz_config.rviz; hero-rviz; cp -f /tmp/rviz_config.rviz $TUE_SYSTEM_DIR/src/hero_bringup/parameters/tools/rviz_config.rviz"
+Exec=bash -c "shopt -s expand_aliases && source ~/.tue/setup.bash; cp -f ${TUE_ENV_WS_DIR}/src/hero_bringup/parameters/tools/rviz_config.rviz /tmp/rviz_config.rviz; hero-rviz; cp -f /tmp/rviz_config.rviz ${TUE_ENV_WS_DIR}/src/hero_bringup/parameters/tools/rviz_config.rviz"
 Name=HERO-rviz
 GenericName=Open rviz with hero config
 X-KDE-StartupNotify=true

--- a/hero-demo-user/setup
+++ b/hero-demo-user/setup
@@ -1,8 +1,11 @@
 #! /usr/bin/env bash
 
-export ROBOT_BRINGUP_PATH=$TUE_SYSTEM_DIR/src/hero_bringup
+# TODO(anyone): remove when tue-env is updated to new variable names
+[[ -v TUE_ENV_WS_DIR || ! -v TUE_WS_DIR ]] || TUE_ENV_WS_DIR=${TUE_WS_DIR}
 
-alias hero='export ROBOT_BRINGUP_PATH=$TUE_SYSTEM_DIR/src/hero_bringup'
+export ROBOT_BRINGUP_PATH=${TUE_ENV_WS_DIR}/src/hero_bringup
+
+alias hero='[[ -v TUE_ENV_WS_DIR || ! -v TUE_WS_DIR ]] || TUE_ENV_WS_DIR=${TUE_WS_DIR}; export ROBOT_BRINGUP_PATH=${TUE_ENV_WS_DIR}/src/hero_bringup'
 
 alias hero-core='_robot-core hero1'
 

--- a/matthijs/setup
+++ b/matthijs/setup
@@ -19,7 +19,7 @@ function sb
     source ~/.bashrc
 }
 
-alias ag='ag -fi'
+alias ag='ag -f'
 
 alias ccat='pygmentize -g -O style=colorful'
 

--- a/qtcreator/README.md
+++ b/qtcreator/README.md
@@ -5,7 +5,7 @@ After installation the following still needs to be done to configure QtCreator w
 1. Open QtCreator
 2. Open Tools -> Options
 3. Select the 'Build & Run' page on the left.
-    - In the 'General' tab change projects directory to `%{Env:TUE_SYSTEM_DIR}/src`
+    - In the 'General' tab change projects directory to `%{Env:TUE_ENV_WS_DIR}/src`
     - In 'Default Build Properties' tab change 'Default build directory' to `%{Env:CURRENT_CMAKE_BUILD_DIR}/%{Project:Name}`
 
 This matches the instructions from the [ROS Wiki](http://wiki.ros.org/IDEs#QtCreator)

--- a/qtcreator/setup
+++ b/qtcreator/setup
@@ -5,6 +5,7 @@ function qtcreator
     /opt/Qt/Tools/QtCreator/bin/qtcreator.sh
 }
 
+# TODO(anyone): remove when tue-env is updated to new variable names
 if [[ ! -v TUE_ENV_ROS_VERSION && -v TUE_ROS_VERSION ]]
 then
     TUE_ENV_ROS_VERSION=${TUE_ROS_VERSION}

--- a/qtcreator/setup
+++ b/qtcreator/setup
@@ -5,12 +5,17 @@ function qtcreator
     /opt/Qt/Tools/QtCreator/bin/qtcreator.sh
 }
 
-if [[ "${TUE_ROS_VERSION}" -eq 1 ]]
+if [[ ! -v TUE_ENV_ROS_VERSION && -v TUE_ROS_VERSION ]]
+then
+    TUE_ENV_ROS_VERSION=${TUE_ROS_VERSION}
+    >&2 echo "Change the config of your environment to use 'TUE_ENV_ROS_VERSION' instead of 'TUE_ROS_VERSION'"
+fi
+if [[ "${TUE_ENV_ROS_VERSION}" -eq 1 ]]
 then
     # Make sure packages can be build by QT
-    CURRENT_CMAKE_BUILD_DIR=$(catkin locate --workspace "${TUE_SYSTEM_DIR}" --build 2>/dev/null)
+    CURRENT_CMAKE_BUILD_DIR=$(catkin locate --workspace "${TUE_ENV_WS_DIR}" --build 2>/dev/null)
 else
-    CURRENT_CMAKE_BUILD_DIR="${TUE_SYSTEM_DIR}"/build
+    CURRENT_CMAKE_BUILD_DIR="${TUE_ENV_WS_DIR}"/build
 fi
 
 export CURRENT_CMAKE_BUILD_DIR

--- a/robot-demo-user/setup
+++ b/robot-demo-user/setup
@@ -29,7 +29,13 @@ GIT_PS1_DESCRIBE_STYLE="branch"
 GIT_PS1_SHOWUPSTREAM="auto git"
 
 function _ROS_MASTER_NAME {
-    [[ "${TUE_ROS_VERSION}" -ne 1 ]] && return
+    # TODO(anyone): remove when tue-env is updated to new variable names
+    if [[ ! -v TUE_ENV_ROS_VERSION && -v TUE_ROS_VERSION ]]
+    then
+        TUE_ENV_ROS_VERSION=${TUE_ROS_VERSION}
+        >&2 echo "Change the config of your environment to use 'TUE_ENV_ROS_VERSION' instead of 'TUE_ROS_VERSION'"
+    fi
+    [[ "${TUE_ENV_ROS_VERSION}" -ne 1 ]] && return
     # shellcheck disable=SC2001
     ROS_MASTER=$(echo "$ROS_MASTER_URI" | sed 's#http://\(.*\):.*#\1#')
     if [ "$ROS_MASTER" == "localhost" ] || [ "$ROBOT_REAL" == "true" ]; then
@@ -40,7 +46,13 @@ function _ROS_MASTER_NAME {
 }
 
 function _ROS2_DISCOVERY {
-    [[ "${TUE_ROS_VERSION}" -ne 2 ]] && return
+    # TODO(anyone): remove when tue-env is updated to new variable names
+    if [[ ! -v TUE_ENV_ROS_VERSION && -v TUE_ROS_VERSION ]]
+    then
+        TUE_ENV_ROS_VERSION=${TUE_ROS_VERSION}
+        >&2 echo "Change the config of your environment to use 'TUE_ENV_ROS_VERSION' instead of 'TUE_ROS_VERSION'"
+    fi
+    [[ "${TUE_ENV_ROS_VERSION}" -ne 2 ]] && return
     # shellcheck disable=SC2153
     local ros_domain_id=${ROS_DOMAIN_ID}
     [[ -n "${ros_domain_id}" ]] || ros_domain_id=0 # default

--- a/ros-swri_console/setup
+++ b/ros-swri_console/setup
@@ -1,5 +1,6 @@
 #! /usr/bin/env bash
 
+# TODO(anyone): remove when tue-env is updated to new variable names
 if [[ ! -v TUE_ENV_ROS_VERSION && -v TUE_ROS_VERSION ]]
 then
     TUE_ENV_ROS_VERSION=${TUE_ROS_VERSION}

--- a/ros-swri_console/setup
+++ b/ros-swri_console/setup
@@ -1,6 +1,11 @@
 #! /usr/bin/env bash
 
-if [[ "${TUE_ROS_VERSION}" -eq 1 ]]
+if [[ ! -v TUE_ENV_ROS_VERSION && -v TUE_ROS_VERSION ]]
+then
+    TUE_ENV_ROS_VERSION=${TUE_ROS_VERSION}
+    >&2 echo "Change the config of your environment to use 'TUE_ENV_ROS_VERSION' instead of 'TUE_ROS_VERSION'"
+fi
+if [[ "${TUE_ENV_ROS_VERSION}" -eq 1 ]]
 then
     alias swri="rosrun swri_console swri_console"
 else

--- a/ros1/install.bash
+++ b/ros1/install.bash
@@ -1,6 +1,7 @@
 #! /usr/bin/env bash
 # shellcheck disable=SC1090
 
+# TODO(anyone): remove when tue-env is updated to new variable names
 if [[ ! -v TUE_ENV_ROS_DISTRO && -v TUE_ROS_DISTRO ]]
 then
     TUE_ENV_ROS_DISTRO=${TUE_ROS_DISTRO}
@@ -28,9 +29,12 @@ then
     touch "$rosdep_update_file"
 fi
 
+# TODO(anyone): remove when tue-env is updated to new variable names
+[[ -v TUE_ENV_WS_DIR || ! -v TUE_WS_DIR ]] || TUE_ENV_WS_DIR=${TUE_WS_DIR}
+
 mkdir -p "${TUE_ENV_WS_DIR}"
 
-if [ ! -f "${TUE_ENV_WS_DIR}"/devel/setup.bash ]
+if [[ ! -f "${TUE_ENV_WS_DIR}"/devel/setup.bash ]]
 then
     [[ -z "${TUE_ENV_ROS_VERSION}" ]] && { tue-install-warning "tue-env variable TUE_ENV_ROS_VERSION is not set. This will not be allowed in the future.\nSetting TUE_ENV_ROS_VERSION=1 temporarily."; }
     [[ "$CI" == "true" ]] && status_args=" --no-status"

--- a/ros1/install.bash
+++ b/ros1/install.bash
@@ -1,14 +1,19 @@
 #! /usr/bin/env bash
 # shellcheck disable=SC1090
 
-if [ -z "$TUE_ROS_DISTRO" ]
+if [[ ! -v TUE_ENV_ROS_DISTRO && -v TUE_ROS_DISTRO ]]
 then
-    tue-install-error "TUE_ROS_DISTRO was not set"
+    TUE_ENV_ROS_DISTRO=${TUE_ROS_DISTRO}
+    >&2 echo "Change the config of your environment to use 'TUE_ENV_ROS_DISTRO' instead of 'TUE_ROS_DISTRO'"
+fi
+if [[ -z "${TUE_ENV_ROS_DISTRO}" ]]
+then
+    tue-install-error "TUE_ENV_ROS_DISTRO was not set"
     return 1
 fi
 
 # Install basic ROS packages.
-tue-install-system-now ros-"$TUE_ROS_DISTRO"-ros
+tue-install-system-now ros-"${TUE_ENV_ROS_DISTRO}"-ros
 
 if [ ! -d /etc/ros/rosdep ]
 then
@@ -19,16 +24,16 @@ rosdep_update_file="/tmp/tue_rosdep_update_${USER}"
 if [ ! -f "$rosdep_update_file" ]
 then
     tue-install-debug "Updating rosdep"
-    tue-install-pipe rosdep update --rosdistro "$TUE_ROS_DISTRO"
+    tue-install-pipe rosdep update --rosdistro "${TUE_ENV_ROS_DISTRO}"
     touch "$rosdep_update_file"
 fi
 
-mkdir -p "$TUE_SYSTEM_DIR"
+mkdir -p "${TUE_ENV_WS_DIR}"
 
-if [ ! -f "$TUE_SYSTEM_DIR"/devel/setup.bash ]
+if [ ! -f "${TUE_ENV_WS_DIR}"/devel/setup.bash ]
 then
-    [[ -z "${TUE_ROS_VERSION}" ]] && { tue-install-warning "tue-env variable TUE_ROS_VERSION is not set. This will not be allowed in the future.\nSetting TUE_ROS_VERSION=1 temporarily."; }
+    [[ -z "${TUE_ENV_ROS_VERSION}" ]] && { tue-install-warning "tue-env variable TUE_ENV_ROS_VERSION is not set. This will not be allowed in the future.\nSetting TUE_ENV_ROS_VERSION=1 temporarily."; }
     [[ "$CI" == "true" ]] && status_args=" --no-status"
     # shellcheck disable=SC2086
-    TUE_ROS_VERSION=1 tue-make${status_args} || tue-install-error "Error in building the system workspace"
+    TUE_ENV_ROS_VERSION=1 tue-make${status_args} || tue-install-error "Error in building the system workspace"
 fi

--- a/ros1/install.bash
+++ b/ros1/install.bash
@@ -5,7 +5,7 @@
 if [[ ! -v TUE_ENV_ROS_DISTRO && -v TUE_ROS_DISTRO ]]
 then
     TUE_ENV_ROS_DISTRO=${TUE_ROS_DISTRO}
-    >&2 echo "Change the config of your environment to use 'TUE_ENV_ROS_DISTRO' instead of 'TUE_ROS_DISTRO'"
+    tue-install-warning "Change the config of your environment to use 'TUE_ENV_ROS_DISTRO' instead of 'TUE_ROS_DISTRO'"
 fi
 if [[ -z "${TUE_ENV_ROS_DISTRO}" ]]
 then

--- a/ros1/setup
+++ b/ros1/setup
@@ -1,19 +1,24 @@
 #! /usr/bin/env bash
 
-if [ -z "$TUE_ROS_DISTRO" ]
+if [[ ! -v TUE_ENV_ROS_DISTRO && -v TUE_ROS_DISTRO ]]
 then
-    echo -e "\e[31;1m[ros] TUE_ROS_DISTRO was not set\e[0m"
+    TUE_ENV_ROS_DISTRO=${TUE_ROS_DISTRO}
+    >&2 echo "Change the config of your environment to use 'TUE_ENV_ROS_DISTRO' instead of 'TUE_ROS_DISTRO'"
+fi
+if [[ -z "${TUE_ENV_ROS_DISTRO}" ]]
+then
+    echo -e "\e[31;1m[ros] TUE_ENV_ROS_DISTRO was not set\e[0m"
     return 1
 fi
 
-if [ -f "$TUE_SYSTEM_DIR"/devel/setup.bash ]
+if [ -f "${TUE_ENV_WS_DIR}"/devel/setup.bash ]
 then
     # shellcheck disable=SC1091
-    source "$TUE_SYSTEM_DIR"/devel/setup.bash
+    source "${TUE_ENV_WS_DIR}"/devel/setup.bash
 else
     echo -e "\e[33;1m[ros] system workspaces not found, sourcing /opt/ros\e[0m"
     # shellcheck disable=SC1090
-    source /opt/ros/"$TUE_ROS_DISTRO"/setup.bash
+    source /opt/ros/"${TUE_ENV_ROS_DISTRO}"/setup.bash
 fi
 
 # Set ROSCONSOLE_FORMAT

--- a/ros1/setup
+++ b/ros1/setup
@@ -1,5 +1,6 @@
 #! /usr/bin/env bash
 
+# TODO(anyone): remove when tue-env is updated to new variable names
 if [[ ! -v TUE_ENV_ROS_DISTRO && -v TUE_ROS_DISTRO ]]
 then
     TUE_ENV_ROS_DISTRO=${TUE_ROS_DISTRO}
@@ -11,7 +12,10 @@ then
     return 1
 fi
 
-if [ -f "${TUE_ENV_WS_DIR}"/devel/setup.bash ]
+# TODO(anyone): remove when tue-env is updated to new variable names
+[[ -v TUE_ENV_WS_DIR || ! -v TUE_WS_DIR ]] || TUE_ENV_WS_DIR=${TUE_WS_DIR}
+
+if [[ -f "${TUE_ENV_WS_DIR}"/devel/setup.bash ]]
 then
     # shellcheck disable=SC1091
     source "${TUE_ENV_WS_DIR}"/devel/setup.bash

--- a/ros2/install.bash
+++ b/ros2/install.bash
@@ -1,20 +1,26 @@
 #! /usr/bin/env bash
 # shellcheck disable=SC1090
 
-if [ -z "$TUE_ROS_DISTRO" ]
+if [[ ! -v TUE_ENV_ROS_DISTRO && -v TUE_ROS_DISTRO ]]
 then
-    tue-install-error "TUE_ROS_DISTRO was not set"
+    TUE_ENV_ROS_DISTRO=${TUE_ROS_DISTRO}
+    >&2 echo "Change the config of your environment to use 'TUE_ENV_ROS_DISTRO' instead of 'TUE_ROS_DISTRO'"
+fi
+if [[ -z "${TUE_ENV_ROS_DISTRO}" ]]
+then
+    tue-install-error "TUE_ENV_ROS_DISTRO was not set"
     return 1
 fi
 
 # Install basic ROS packages and eProsima DDS implementation.
-tue-install-system-now ros-"$TUE_ROS_DISTRO"-ros-core ros-"$TUE_ROS_DISTRO"-rmw-fastrtps-cpp
+tue-install-system-now ros-"${TUE_ENV_ROS_DISTRO}"-ros-core ros-"${TUE_ENV_ROS_DISTRO}"-rmw-fastrtps-cpp
 
 # Setup the build environment
-mkdir -p "$TUE_SYSTEM_DIR"
+mkdir -p "${TUE_ENV_WS_DIR}"
 
-if [ ! -f "$TUE_SYSTEM_DIR"/install/setup.bash ]
+if [ ! -f "$TUE_ENV_WS_DIR"/install/setup.bash ]
 then
-    [[ -z "${TUE_ROS_VERSION}" ]] && { tue-install-warning "tue-env variable TUE_ROS_VERSION is not set. This will not be allowed in the future.\nSetting TUE_ROS_VERSION=2 temporarily."; }
-    TUE_ROS_VERSION=2 tue-make || tue-install-error "Error in building the ROS2 system workspace"
+    [[ -v TUE_ENV_ROS_VERSION || -v TUE_ROS_VERSION ]] || { TUE_ENV_ROS_VERSION=${TUE_ROS_VERSION}; tue-install-warning "Change the config of your environment to use 'TUE_ENV_ROS_DISTRO' instead of 'TUE_ROS_DISTRO'"; }
+    [[ -z "${TUE_ENV_ROS_VERSION}" ]] && { tue-install-warning "tue-env variable TUE_ENV_ROS_VERSION is not set. This will not be allowed in the future.\nSetting TUE_ENV_ROS_VERSION=2 temporarily."; }
+    TUE_ENV_ROS_VERSION=2 tue-make || tue-install-error "Error in building the ROS2 system workspace"
 fi

--- a/ros2/install.bash
+++ b/ros2/install.bash
@@ -1,6 +1,7 @@
 #! /usr/bin/env bash
 # shellcheck disable=SC1090
 
+# TODO(anyone): remove when tue-env is updated to new variable names
 if [[ ! -v TUE_ENV_ROS_DISTRO && -v TUE_ROS_DISTRO ]]
 then
     TUE_ENV_ROS_DISTRO=${TUE_ROS_DISTRO}
@@ -15,10 +16,13 @@ fi
 # Install basic ROS packages and eProsima DDS implementation.
 tue-install-system-now ros-"${TUE_ENV_ROS_DISTRO}"-ros-core ros-"${TUE_ENV_ROS_DISTRO}"-rmw-fastrtps-cpp
 
+# TODO(anyone): remove when tue-env is updated to new variable names
+[[ -v TUE_ENV_WS_DIR || ! -v TUE_WS_DIR ]] || TUE_ENV_WS_DIR=${TUE_WS_DIR}
+
 # Setup the build environment
 mkdir -p "${TUE_ENV_WS_DIR}"
 
-if [ ! -f "$TUE_ENV_WS_DIR"/install/setup.bash ]
+if [[ ! -f "${TUE_ENV_WS_DIR}"/install/setup.bash ]]
 then
     [[ -v TUE_ENV_ROS_VERSION || -v TUE_ROS_VERSION ]] || { TUE_ENV_ROS_VERSION=${TUE_ROS_VERSION}; tue-install-warning "Change the config of your environment to use 'TUE_ENV_ROS_DISTRO' instead of 'TUE_ROS_DISTRO'"; }
     [[ -z "${TUE_ENV_ROS_VERSION}" ]] && { tue-install-warning "tue-env variable TUE_ENV_ROS_VERSION is not set. This will not be allowed in the future.\nSetting TUE_ENV_ROS_VERSION=2 temporarily."; }

--- a/ros2/install.bash
+++ b/ros2/install.bash
@@ -5,7 +5,7 @@
 if [[ ! -v TUE_ENV_ROS_DISTRO && -v TUE_ROS_DISTRO ]]
 then
     TUE_ENV_ROS_DISTRO=${TUE_ROS_DISTRO}
-    >&2 echo "Change the config of your environment to use 'TUE_ENV_ROS_DISTRO' instead of 'TUE_ROS_DISTRO'"
+    tue-install-warning "Change the config of your environment to use 'TUE_ENV_ROS_DISTRO' instead of 'TUE_ROS_DISTRO'"
 fi
 if [[ -z "${TUE_ENV_ROS_DISTRO}" ]]
 then

--- a/ros2/setup
+++ b/ros2/setup
@@ -1,5 +1,6 @@
 #! /usr/bin/env bash
 
+# TODO(anyone): remove when tue-env is updated to new variable names
 if [[ ! -v TUE_ENV_ROS_DISTRO && -v TUE_ROS_DISTRO ]]
 then
     TUE_ENV_ROS_DISTRO=${TUE_ROS_DISTRO}
@@ -19,6 +20,9 @@ then
 else
     echo -e "\033[33;1m[ros2] ROS 2 ${TUE_ENV_ROS_DISTRO} setup.bash not found. \033[0m"
 fi
+
+# TODO(anyone): remove when tue-env is updated to new variable names
+[[ -v TUE_ENV_WS_DIR || ! -v TUE_WS_DIR ]] || TUE_ENV_WS_DIR=${TUE_WS_DIR}
 
 if [[ -f "${TUE_ENV_WS_DIR}/install/local_setup.bash" ]]
 then

--- a/ros2/setup
+++ b/ros2/setup
@@ -1,26 +1,31 @@
 #! /usr/bin/env bash
 
-if [ -z "$TUE_ROS_DISTRO" ]
+if [[ ! -v TUE_ENV_ROS_DISTRO && -v TUE_ROS_DISTRO ]]
 then
-    echo "[ros2] TUE_ROS_DISTRO was not set"
+    TUE_ENV_ROS_DISTRO=${TUE_ROS_DISTRO}
+    >&2 echo "Change the config of your environment to use 'TUE_ENV_ROS_DISTRO' instead of 'TUE_ROS_DISTRO'"
+fi
+if [[ -z "${TUE_ENV_ROS_DISTRO}" ]]
+then
+    echo "[ros2] TUE_ENV_ROS_DISTRO was not set"
     return 1
 fi
 
 # Add ROS sourcing to the shell startup script
-if [ -f "/opt/ros/${TUE_ROS_DISTRO}/setup.bash" ]
+if [[ -f "/opt/ros/${TUE_ENV_ROS_DISTRO}/setup.bash" ]]
 then
     # shellcheck disable=SC1090
-    source "/opt/ros/${TUE_ROS_DISTRO}/setup.bash"
+    source "/opt/ros/${TUE_ENV_ROS_DISTRO}/setup.bash"
 else
-    echo -e "\033[33;1m[ros2] ROS 2 ${TUE_ROS_DISTRO} setup.bash not found. \033[0m"
+    echo -e "\033[33;1m[ros2] ROS 2 ${TUE_ENV_ROS_DISTRO} setup.bash not found. \033[0m"
 fi
 
-if [ -f "${TUE_SYSTEM_DIR}/install/local_setup.bash" ]
+if [[ -f "${TUE_ENV_WS_DIR}/install/local_setup.bash" ]]
 then
     # shellcheck disable=SC1091
-    source "${TUE_SYSTEM_DIR}/install/local_setup.bash"
+    source "${TUE_ENV_WS_DIR}/install/local_setup.bash"
 else
-    echo -e "\033[33;1m[ros2] ${TUE_SYSTEM_DIR}/install/local_setup.bash not found. \033[0m"
+    echo -e "\033[33;1m[ros2] ${TUE_ENV_WS_DIR}/install/local_setup.bash not found. \033[0m"
 fi
 
 # Add Colcon sourcing to the shell startup script
@@ -29,7 +34,7 @@ then
     # shellcheck disable=SC1091
     source /usr/share/colcon_cd/function/colcon_cd.sh
     # shellcheck disable=SC2016
-    export _colcon_cd_root="${TUE_SYSTEM_DIR}"
+    export _colcon_cd_root="${TUE_ENV_WS_DIR}"
 else
     echo -e "\033[33;5;1m[ros2] colcon_cd setup not found. colcon_cd command disabled. \033[0m"
 fi

--- a/sergio-user/setup
+++ b/sergio-user/setup
@@ -1,6 +1,9 @@
 #! /usr/bin/env bash
 
-export ROBOT_BRINGUP_PATH=$TUE_SYSTEM_DIR/src/sergio_bringup
+# TODO(anyone): remove when tue-env is updated to new variable names
+[[ -v TUE_ENV_WS_DIR || ! -v TUE_WS_DIR ]] || TUE_ENV_WS_DIR=${TUE_WS_DIR}
+
+export ROBOT_BRINGUP_PATH=${TUE_ENV_WS_DIR}/src/sergio_bringup
 alias sergio-core='_robot-core sergio1'
 
 # ----------------------------------------------------------------------------
@@ -70,10 +73,10 @@ alias sergio-show-ed-kinect='rosrun rgbd multitool --rgbd /sergio/ed/kinect/viz/
 #
 ####################
 
-alias sergio='export ROBOT_BRINGUP_PATH=$TUE_SYSTEM_DIR/src/sergio_bringup'
+alias sergio='[[ -v TUE_ENV_WS_DIR || ! -v TUE_WS_DIR ]] || TUE_ENV_WS_DIR=${TUE_WS_DIR}; export ROBOT_BRINGUP_PATH=${TUE_ENV_WS_DIR}/src/sergio_bringup'
 
 alias sergio-continui='rosrun hmi_server continue_gui.py __ns:=sergio/hmi'
-alias sergio-continui-gpsr='rosrun hmi_server continue_gui.py $TUE_SYSTEM_DIR/src/challenge_gpsr/src/grammar_gui.fcfg __ns:=sergio/hmi'
+alias sergio-continui-gpsr='[[ -v TUE_ENV_WS_DIR || ! -v TUE_WS_DIR ]] || TUE_ENV_WS_DIR=${TUE_WS_DIR}; rosrun hmi_server continue_gui.py ${TUE_ENV_WS_DIR}/src/challenge_gpsr/src/grammar_gui.fcfg __ns:=sergio/hmi'
 
 ####################
 #

--- a/tue-documentation/README.md
+++ b/tue-documentation/README.md
@@ -13,7 +13,7 @@ To do this create a yaml file in the main folder of your package, for consistenc
 
 Check [Python](#Python) and [C++](#c) for the configuration of the `rosdoc` configuration.
 
-The overview page is configured by the [catkin_tools_document_config.yaml](./catkin_tools_document_config.yaml) in this target. The image path is relative to the `$TUE_SYSTEM_DIR/build/docs`. It ends up here in this target. This is possible as the target location relative to the workspace is fixed.
+The overview page is configured by the [catkin_tools_document_config.yaml](./catkin_tools_document_config.yaml) in this target. The image path is relative to the `${TUE_ENV_WS_DIR}/build/docs`. It ends up here in this target. This is possible as the target location relative to the workspace is fixed.
 
 ## Generation
 

--- a/tue-documentation/setup
+++ b/tue-documentation/setup
@@ -8,21 +8,31 @@ export CATKIN_TOOLS_DOCUMENT_CONFIG_FILE
 # Function to generate doucmentation of current workspace
 function tue-make-documentation
 {
-    if [ -n "$TUE_ROS_DISTRO" ] && [ -d "$TUE_SYSTEM_DIR" ]
+    # TODO(anyone): remove when tue-env is updated to new variable names
+    [[ -v TUE_ENV_WS_DIR || ! -v TUE_WS_DIR ]] || TUE_ENV_WS_DIR=${TUE_WS_DIR}
+
+        # TODO(anyone): remove when tue-env is updated to new variable names
+    if [[ ! -v TUE_ENV_ROS_DISTRO && -v TUE_ROS_DISTRO ]]
+    then
+        TUE_ENV_ROS_DISTRO=${TUE_ROS_DISTRO}
+        >&2 echo "Change the config of your environment to use 'TUE_ENV_ROS_DISTRO' instead of 'TUE_ROS_DISTRO'"
+    fi
+
+    if [[ -n "${TUE_ENV_ROS_DISTRO}" ]] && [[ -d "${TUE_ENV_WS_DIR}" ]]
     then
         local build_tool=""
-        if [ -f "$TUE_SYSTEM_DIR"/build/.built_by ]
+        if [[ -f "${TUE_ENV_WS_DIR}"/build/.built_by ]]
         then
-            build_tool=$(cat "$TUE_SYSTEM_DIR"/build/.built_by)
+            build_tool=$(cat "${TUE_ENV_WS_DIR}"/build/.built_by)
         fi
         case $build_tool in
         'catkin build')
-            catkin document --workspace "$TUE_SYSTEM_DIR" "$@"
+            catkin document --workspace "${TUE_ENV_WS_DIR}" "$@"
             ;;
         '')
-            catkin config --init --mkdirs --workspace "$TUE_SYSTEM_DIR" --extend /opt/ros/"$TUE_ROS_DISTRO" -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCATKIN_ENABLE_TESTING=OFF
-            catkin document --workspace "$TUE_SYSTEM_DIR" "$@"
-            touch "$TUE_SYSTEM_DIR"/devel/.catkin # hack to allow overlaying to this ws while being empty
+            catkin config --init --mkdirs --workspace "${TUE_ENV_WS_DIR}" --extend /opt/ros/"${TUE_ENV_ROS_DISTRO}" -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCATKIN_ENABLE_TESTING=OFF
+            catkin document --workspace "${TUE_ENV_WS_DIR}" "$@"
+            touch "${TUE_ENV_WS_DIR}"/devel/.catkin # hack to allow overlaying to this ws while being empty
             ;;
         *)
             echo -e "\e$build_tool is not supported (anymore), use catkin tools\e[0m"
@@ -36,6 +46,9 @@ export -f tue-make-documentation
 # Use complete function of tue-make
 complete -F _tue-make tue-make-documentation
 
+# TODO(anyone): remove when tue-env is updated to new variable names
+[[ -v TUE_ENV_WS_DIR || ! -v TUE_WS_DIR ]] || TUE_ENV_WS_DIR=${TUE_WS_DIR}
+
 # Export docs path to open with desiserd browser
-TUE_DOCS_PATH="$TUE_SYSTEM_DIR"/docs/index.html
+TUE_DOCS_PATH="${TUE_ENV_WS_DIR}"/docs/index.html
 export TUE_DOCS_PATH

--- a/tue_gazebo_plugins/setup
+++ b/tue_gazebo_plugins/setup
@@ -1,7 +1,10 @@
 #! /usr/bin/env bash
 
-export GAZEBO_PLUGIN_PATH=~/ros/$TUE_ROS_DISTRO/system/devel/lib:$GAZEBO_PLUGIN_PATH
+# TODO(anyone): remove when tue-env is updated to new variable names
+[[ -v TUE_ENV_WS_DIR || ! -v TUE_WS_DIR ]] || TUE_ENV_WS_DIR=${TUE_WS_DIR}
 
-export GAZEBO_MODEL_PATH=~/ros/$TUE_ROS_DISTRO/system/src/tue_gazebo_models/database:$GAZEBO_MODEL_PATH
+export GAZEBO_PLUGIN_PATH=~/${TUE_ENV_WS_DIR}/devel/lib:${GAZEBO_PLUGIN_PATH}
 
-export GAZEBO_RESOURCE_PATH=~/ros/$TUE_ROS_DISTRO/system/src/tue_gazebo_models/database:$GAZEBO_RESOURCE_PATH
+export GAZEBO_MODEL_PATH=~/${TUE_ENV_WS_DIR}/src/tue_gazebo_models/database:${GAZEBO_MODEL_PATH}
+
+export GAZEBO_RESOURCE_PATH=~/${TUE_ENV_WS_DIR}/src/tue_gazebo_models/database:${GAZEBO_RESOURCE_PATH}

--- a/vscode/install.bash
+++ b/vscode/install.bash
@@ -10,6 +10,9 @@ code --install-extension ms-iot.vscode-ros\
      --install-extension tyriar.sort-lines\
      --force
 
+# TODO(anyone): remove when tue-env is updated to new variable names
+[[ -v TUE_ENV_WS_DIR || ! -v TUE_WS_DIR ]] || TUE_ENV_WS_DIR=${TUE_WS_DIR}
+
 # Configure workspace
 workspacefile="${TUE_ENV_WS_DIR}/.vscode/settings.json"
 mkdir -p "${TUE_ENV_WS_DIR}/.vscode"
@@ -26,9 +29,9 @@ fi
 if [[ "${TUE_ENV_ROS_VERSION}" == "1" ]]
 then
     # Install and configure catkin tools extension
-    if ! catkin config --workspace "$TUE_ENV_WS_DIR" | grep -q "DCMAKE_EXPORT_COMPILE_COMMANDS"
+    if ! catkin config --workspace "${TUE_ENV_WS_DIR}" | grep -q "DCMAKE_EXPORT_COMPILE_COMMANDS"
     then
-        catkin config --workspace "$TUE_ENV_WS_DIR" --append-args -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+        catkin config --workspace "${TUE_ENV_WS_DIR}" --append-args -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
     fi
 fi
 

--- a/vscode/install.bash
+++ b/vscode/install.bash
@@ -11,8 +11,8 @@ code --install-extension ms-iot.vscode-ros\
      --force
 
 # Configure workspace
-workspacefile="${TUE_SYSTEM_DIR}/.vscode/settings.json"
-mkdir -p "${TUE_SYSTEM_DIR}/.vscode"
+workspacefile="${TUE_ENV_WS_DIR}/.vscode/settings.json"
+mkdir -p "${TUE_ENV_WS_DIR}/.vscode"
 if [[ ! -f "${workspacefile}" ]]
 then
     tue-install-cp workspace_settings.json "${workspacefile}"
@@ -23,14 +23,17 @@ else
     fi
 fi
 
-# Install and configure catkin tools extension
-if ! catkin config --workspace "$TUE_SYSTEM_DIR" | grep -q "DCMAKE_EXPORT_COMPILE_COMMANDS"
+if [[ "${TUE_ENV_ROS_VERSION}" == "1" ]]
 then
-    catkin config --workspace "$TUE_SYSTEM_DIR" --append-args -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+    # Install and configure catkin tools extension
+    if ! catkin config --workspace "$TUE_ENV_WS_DIR" | grep -q "DCMAKE_EXPORT_COMPILE_COMMANDS"
+    then
+        catkin config --workspace "$TUE_ENV_WS_DIR" --append-args -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+    fi
 fi
 
 # Configure to build only active package
-tasksfile="${TUE_SYSTEM_DIR}/.vscode/tasks.json"
+tasksfile="${TUE_ENV_WS_DIR}/.vscode/tasks.json"
 if [[ ! -f "${tasksfile}" ]]  # If user already has one, don't overwrite
 then
     tue-install-cp tasks.json "${tasksfile}"


### PR DESCRIPTION
Tested with the master branch of tue-env, [tue-env#58854fd6efd03bd5700e0a6039c7a8dcb72dad79](https://github.com/tue-robotics/tue-env/tree/58854fd6efd03bd5700e0a6039c7a8dcb72dad79), in three different situations:
- https://github.com/tue-robotics/tue-robotics.github.io/actions/runs/8876108892
- https://github.com/tue-robotics/ed/actions/runs/8876682906
- https://github.com/tue-robotics/pykdl_ros/actions/runs/8879165488