### PR TITLE
Revert "[python-sphinx-autoapi-pip][TEMP] limit version (#454)"

### DIFF
--- a/python-sphinx-autoapi-pip/install.yaml
+++ b/python-sphinx-autoapi-pip/install.yaml
@@ -1,2 +1,2 @@
 - type: pip
-  name: sphinx-autoapi<3.4.0
+  name: sphinx-autoapi


### PR DESCRIPTION
This reverts commit f37848f68f7e1eb28c361ec33b19f40d630472df.

Fixed by https://github.com/readthedocs/sphinx-autoapi/commit/1c0a669e85aa670ab768aed5f72082e313ef832e