### PR TITLE
[ros-robot_launch_files] migrated to ros2

### DIFF
--- a/ros-robot_launch_files/install.yaml
+++ b/ros-robot_launch_files/install.yaml
@@ -1,4 +1,10 @@
 - type: ros
-  source:
-    type: git
-    url: https://github.com/tue-robotics/robot_launch_files.git
+  default:
+    source:
+      type: git
+      url: https://github.com/tue-robotics/robot_launch_files.git
+  noetic:
+    source:
+      type: git
+      url: https://github.com/tue-robotics/robot_launch_files.git
+      version: ros1


### PR DESCRIPTION
Splits the target so ROS 2 distros track `master` while Noetic tracks the `ros1` branch, the same way [#557](https://github.com/tue-robotics/tue-env-targets/pull/557) did it for `ros-ed`.

Needed for tue-robotics/robot_launch_files#86, which converts all 41 launch files from ROS 1 XML to ROS 2 Python and switches the package to `ament_cmake`. Without this split a Noetic workspace would pull the ROS 2 launch files from `master` once that PR merges.

The `ros1` branch already exists and points at `cf7b017`, the last commit before the migration.

Merge order: this PR can merge first, it is a no-op until robot_launch_files#86 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)