### PR TITLE
[ros-ed_object_models] migrated to ros2

### DIFF
--- a/gazebo_models/setup
+++ b/gazebo_models/setup
@@ -4,4 +4,7 @@ model_path=$HOME/data/gazebo_models
 
 export GAZEBO_MODEL_PATH=${GAZEBO_MODEL_PATH:+${GAZEBO_MODEL_PATH}:}$model_path
 export GAZEBO_RESOURCE_PATH=${GAZEBO_RESOURCE_PATH:+${GAZEBO_RESOURCE_PATH}:}$model_path
+# GZ_SIM_RESOURCE_PATH is the new Gazebo's equivalent of GAZEBO_MODEL_PATH; harmless to export on
+# Gazebo classic / Noetic too, since nothing there reads it.
+export GZ_SIM_RESOURCE_PATH=${GZ_SIM_RESOURCE_PATH:+${GZ_SIM_RESOURCE_PATH}:}$model_path
 

--- a/ros-ed_object_models/install.yaml
+++ b/ros-ed_object_models/install.yaml
@@ -1,4 +1,10 @@
 - type: ros
-  source:
-    type: git
-    url: https://github.com/tue-robotics/ed_object_models.git
+  default:
+    source:
+      type: git
+      url: https://github.com/tue-robotics/ed_object_models.git
+  noetic:
+    source:
+      type: git
+      url: https://github.com/tue-robotics/ed_object_models.git
+      version: ros1

--- a/ros-ros_gz_interfaces/install.yaml
+++ b/ros-ros_gz_interfaces/install.yaml
@@ -1,0 +1,8 @@
+- type: ros
+  noetic:
+    source:
+      null
+  default:
+    source:
+      type: system
+      name: ros-gz-interfaces

--- a/tue-save-map/setup
+++ b/tue-save-map/setup
@@ -35,7 +35,12 @@ The map will be stored in the package ed_object_models, in folder models/MAP_NAM
     robot_name=$1
     map_name=$2
 
-    MODELS_DIR=$(rospack find ed_object_models)/models
+    if [[ "${TUE_ENV_ROS_VERSION}" -eq 1 ]]
+    then
+        MODELS_DIR=$(rospack find ed_object_models)/models
+    else
+        MODELS_DIR=$(ros2 pkg prefix --share ed_object_models)/models
+    fi
     MODEL_DIR="$MODELS_DIR"/$map_name
 
     if [ -d "$MODEL_DIR" ]; then
@@ -51,6 +56,9 @@ The map will be stored in the package ed_object_models, in folder models/MAP_NAM
 
 
     # store the map in /tmp
+    # TODO(ros2): map_server has no ROS 2 build yet (tracked in robot_launch_files' ros2_migration.md);
+    # its replacement is nav2_map_server, e.g.:
+    # ros2 run nav2_map_server map_saver_cli -f /tmp/temp_map -t /"$robot_name"/gmapping/map
     rosrun map_server map_saver -f /tmp/temp_map /map:=/"$robot_name"/gmapping/map
 
     # parse yaml from gmapping


### PR DESCRIPTION
Follow-up to tue-robotics/ed_object_models#130.

- `ros-ed_object_models/install.yaml`: split into `default`/`noetic`, same shape as `ros-ed` and `ros-upower_ros` — ROS 2 distros track `master`, Noetic keeps tracking the `ros1` branch.
- `tue-save-map/setup`: `rospack find ed_object_models` has no ROS 2 equivalent, and the models directory this function resolves now lives under `share/ed_object_models/models` in ROS 2. Branches on `TUE_ENV_ROS_VERSION` and uses `ros2 pkg prefix --share ed_object_models` on ROS 2.

The `rosrun map_server map_saver` call in the same function is left untouched (ROS 1 only) with a `TODO(ros2)` note pointing at `nav2_map_server` — `map_server` itself isn't built for ROS 2 yet in this org, tracked separately in `robot_launch_files`' `ros2_migration.md` (§5/§6). Swapping it in is a separate change once that port happens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)